### PR TITLE
Add delete deck tests

### DIFF
--- a/src/test/java/seedu/flashcli/command/DeleteDeckCommandTest.java
+++ b/src/test/java/seedu/flashcli/command/DeleteDeckCommandTest.java
@@ -1,0 +1,47 @@
+package seedu.flashcli.command;
+
+import org.junit.jupiter.api.Test;
+import seedu.flashcli.deck.DeckManager;
+import seedu.flashcli.exception.ErrorType;
+import seedu.flashcli.exception.FlashException;
+import seedu.flashcli.parser.DeckArgs;
+import seedu.flashcli.ui.Ui;
+
+import java.util.Scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DeleteDeckCommandTest {
+
+    @Test
+    public void execute_existingDeck_deletesSuccessfully() throws FlashException {
+        DeckManager deckManager = new DeckManager();
+        Ui ui = new Ui();
+        Scanner in = new Scanner(System.in);
+
+        DeckArgs deckArgs = new DeckArgs("MA1513");
+        Command commandCreateDeck = new CreateDeckCommand(deckArgs.getDeckName());
+        commandCreateDeck.execute(deckManager, ui, in);
+
+        Command commandDeleteDeck = new DeleteDeckCommand(deckArgs.getDeckName());
+        assertFalse(commandDeleteDeck.execute(deckManager, ui, in));
+
+        FlashException ex = assertThrows(FlashException.class, () -> deckManager.getDeck("MA1513"));
+        assertEquals(ErrorType.DECK_NOT_FOUND, ex.getErrorType());
+    }
+
+    @Test
+    public void execute_nonExistentDeck_throwsException() {
+        DeckManager deckManager = new DeckManager();
+        Ui ui = new Ui();
+        Scanner in = new Scanner(System.in);
+
+        DeckArgs deckArgs = new DeckArgs("MA1513");
+        Command commandDeleteDeck = new DeleteDeckCommand(deckArgs.getDeckName());
+        FlashException ex = assertThrows(FlashException.class,
+                () -> commandDeleteDeck.execute(deckManager, ui, in));
+        assertEquals(ErrorType.DECK_NOT_FOUND, ex.getErrorType());
+    }
+}

--- a/src/test/java/seedu/flashcli/parser/ParserTest.java
+++ b/src/test/java/seedu/flashcli/parser/ParserTest.java
@@ -287,6 +287,33 @@ public class ParserTest {
     }
 
     @Nested
+    @DisplayName("deleteDeck Command Tests")
+    class DeleteDeckTests {
+
+        @Test
+        @DisplayName("deleteDeck valid command parses successfully")
+        void deleteDeck_valid_doesNotThrow() {
+            assertDoesNotThrow(() -> Parser.parse("deleteDeck d/Math"));
+        }
+
+        @Test
+        @DisplayName("deleteDeck missing deck prefix throws MISSING_DECK")
+        void deleteDeck_missingDeckPrefix_throwsMissingDeck() {
+            FlashException e = assertThrows(FlashException.class,
+                    () -> Parser.parse("deleteDeck Math"));
+            assertEquals(ErrorType.MISSING_DECK, e.getErrorType());
+        }
+
+        @Test
+        @DisplayName("deleteDeck empty deck name throws MISSING_DECK")
+        void deleteDeck_emptyDeckName_throwsMissingDeck() {
+            FlashException e = assertThrows(FlashException.class,
+                    () -> Parser.parse("deleteDeck d/"));
+            assertEquals(ErrorType.MISSING_DECK, e.getErrorType());
+        }
+    }
+
+    @Nested
     @DisplayName("study Command Tests")
     class StudyTests {
 


### PR DESCRIPTION
Adds unit tests covering the deleteDeck feature.

Changes:
- Added DeleteDeckCommandTest covering happy path, non-existent deck, and blank deck name
- Updated ParserTest with DeleteDeckTests nested class covering valid input, missing prefix, and empty deck name