### PR TITLE
Improve confirmation feedback and update UG documentation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -162,7 +162,7 @@ listDecks
 
 ### Deleting a deck : `deleteDeck`
 
-Permanently removes the named deck and all its cards.
+Permanently removes the named deck and all its cards. Requires a confirmation message ('yes') from the user to execute. The confirmation message is intentionally case sensitive so that the destructive action is only carried out when the user provides a deliberate and unambiguous input.
 
 **Format:** `deleteDeck d/DECK_NAME`
 
@@ -175,7 +175,7 @@ deleteDeck d/Linear Algebra
 
 ### Clearing a deck : `clearDeck`
 
-Removes all cards from an existing deck without deleting the deck itself.
+Removes all cards from an existing deck without deleting the deck itself. Requires a confirmation message ('yes') from the user to execute. The confirmation message is intentionally case sensitive so that the destructive action is only carried out when the user provides a deliberate and unambiguous input.
 
 **Format:** `clearDeck d/DECK_NAME`
 

--- a/src/main/java/seedu/flashcli/command/ClearDeckCommand.java
+++ b/src/main/java/seedu/flashcli/command/ClearDeckCommand.java
@@ -30,6 +30,7 @@ public class ClearDeckCommand implements Command {
             ui.clearConfirmationPrompt(deckName);
             String userConfirmation = in.nextLine();
             if (!userConfirmation.equals("yes")) {
+                ui.rejectConfirmationPrompt();
                 return false;
             }
             Deck deck = deckManager.getDeck(deckName);

--- a/src/main/java/seedu/flashcli/command/DeleteDeckCommand.java
+++ b/src/main/java/seedu/flashcli/command/DeleteDeckCommand.java
@@ -36,6 +36,7 @@ public class DeleteDeckCommand implements Command {
             ui.deleteConfirmationPrompt(deckName);
             String userConfirmation = in.nextLine();
             if (!userConfirmation.equals("yes")) {
+                ui.rejectConfirmationPrompt();
                 return false;
             }
             deckManager.deleteDeck(deckName);

--- a/src/main/java/seedu/flashcli/ui/Ui.java
+++ b/src/main/java/seedu/flashcli/ui/Ui.java
@@ -218,7 +218,7 @@ public class Ui {
     public void deleteConfirmationPrompt(String deckName) {
         System.out.println("This action will irreversibly delete the deck "
             + deckName
-            + ". Enter 'yes' to proceed");
+            + ". Enter 'yes' (all lowercase) to proceed");
     }
 
     /**
@@ -228,7 +228,14 @@ public class Ui {
     public void clearConfirmationPrompt(String deckName) {
         System.out.println("This action will irreversibly clear the deck "
             + deckName
-            + ". Enter 'yes' to proceed");
+            + ". Enter 'yes' (all lowercase) to proceed");
+    }
+
+    /**
+     * Shows user that command was aborted because the confirmation response they entered was incorrect.
+     */
+    public void rejectConfirmationPrompt() {
+        System.out.println("Failed to receive correct confirmation response. Command aborted.");
     }
 
     /**


### PR DESCRIPTION
Improves user feedback and documentation for confirmation-based commands (delete and clear deck commands).

- Added explicit message to inform users when a command is aborted due to incorrect confirmation input
- Updated User Guide to include documentation for confirmation requirement and behaviour

Closes #199 